### PR TITLE
Add Dockerfile to make shmarql instance

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,31 @@
+name: Docker Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - odk
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to GitHub Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: downcase REPO
+        run: |
+          echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+          echo ${REPO}
+          echo ${GITHUB_REPOSITORY}
+      - name: Build and Push
+        env:
+          REGISTRY: ghcr.io
+        run: |
+          docker build -t $REGISTRY/${REPO}:latest -t $REGISTRY/${REPO}:$(date +%s) .  
+          docker push $REGISTRY/${REPO} --all-tags

--- a/Dockerfile_docs
+++ b/Dockerfile_docs
@@ -1,0 +1,17 @@
+FROM openjdk:jre AS widoco
+
+RUN wget -O widoco.jar https://github.com/dgarijo/Widoco/releases/download/v1.4.25/widoco-1.4.25-jar-with-dependencies_JDK-11.jar 
+
+COPY nfdicore.ttl .
+
+RUN java -jar widoco.jar -ontFile nfdicore.ttl -outFolder public -uniteSections -includeAnnotationProperties -lang en-de -getOntologyMetadata -noPlaceHolderText -rewriteAll -webVowl
+
+FROM ghcr.io/epoz/shmarql:latest
+
+COPY nfdicore.ttl .
+COPY docs /src/docs
+COPY mkdocs.yaml a.yml
+RUN python -m shmarql docs_build -f a.yml
+
+COPY --from=widoco /public/doc /src/site/ontology
+RUN cp /src/site/ontology/index-en.html /src/site/ontology/index.html

--- a/docs/overrides/partials/copyright.html
+++ b/docs/overrides/partials/copyright.html
@@ -1,0 +1,15 @@
+{#-
+  This file was automatically generated - do not edit
+-#}
+<div class="md-copyright">
+  {% if config.copyright %}
+    <div class="md-copyright__highlight">
+      {{ config.copyright }}
+    </div>
+  {% endif %}
+  {% if not config.extra.generator == false %}
+    <a href="https://www.fiz-karlsruhe.de/en/bereiche/information-service-engineering" target="_blank">Information Service Engineering Group at FIZ Karlsruhe</a>
+    <span style="font-size: 150%; font-weight: bold; margin: 0 2ch 0 2ch">&#8756;</span> 
+    
+  {% endif %}
+</div>


### PR DESCRIPTION
This pull request adds a Dockerfile and a Github action to make a SHMARQL container image for the docs.

To test this locally, you can build the image like this:
```
docker build -t nfdicore -f Dockerfile_docs .
```

And then you can run the image:
```
docker run --rm -it -p 8000:8000 -e DATA_LOAD_PATHS=/src -e DEBUG=1 nfdicore
```

If all goes well, you can view the docs at: http://localhost:8000/

Once we agree with this, we can then publish it to:
`https://nfdi.fiz-karlsruhe.de/ontology/`