### PR TITLE
Add mappings to T4FS for data handling processes

### DIFF
--- a/src/ontology/nfdicore-edit.owl
+++ b/src/ontology/nfdicore-edit.owl
@@ -33,8 +33,13 @@ Annotation(<http://purl.org/vocab/vann/preferredNamespaceUri> <https://nfdi.fiz-
 Annotation(rdfs:label "NFDIcore")
 
 Declaration(AnnotationProperty(<http://purl.org/ontology/bibo/status>))
+Declaration(AnnotationProperty(<http://www.w3.org/2004/02/skos/core#exactMatch>))
 
 
+AnnotationAssertion(rdfs:seeAlso <https://nfdi.fiz-karlsruhe.de/ontology/NFDI_0010028> <http://purl.obolibrary.org/obo/T4FS_0000012>)
+AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#exactMatch> <https://nfdi.fiz-karlsruhe.de/ontology/NFDI_0010030> <http://purl.obolibrary.org/obo/T4FS_0000044>)
+AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#exactMatch> <https://nfdi.fiz-karlsruhe.de/ontology/NFDI_0010034> <http://purl.obolibrary.org/obo/T4FS_0000384>)
+AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#exactMatch> <https://nfdi.fiz-karlsruhe.de/ontology/NFDI_0010036> <http://purl.obolibrary.org/obo/T4FS_0000487>)
 AnnotationAssertion(rdfs:label <https://nfdi4culture.de/id/E1925> "Harald Sack")
 AnnotationAssertion(rdfs:label <https://nfdi4culture.de/id/E2415> "Tabea Tietz")
 AnnotationAssertion(rdfs:label <https://nfdi4culture.de/id/E2416> "Oleksandra Bruns")


### PR DESCRIPTION
The terms4FAIRSkills (T4FS) ontology has a ["data stewardship activity" hierarchy](https://www.ebi.ac.uk/ols4/ontologies/t4fs/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FT4FS_0000012?lang=en) under BFO:process that partially overlaps with nfdicore's "data handling process" hierarchy

This PR makes some SKOS-based exact match annotations for three that are the same, and adds a see also annotation for the upper level.